### PR TITLE
Both icmps

### DIFF
--- a/scripts/CVE-2020-16898.zeek
+++ b/scripts/CVE-2020-16898.zeek
@@ -22,7 +22,7 @@ export {
 # exactly one baseline file for the tests. Essentially, fields with shared names between `icmp_info`
 # and `icmp_conn` will use `i` and `ttl` will be used for the variable where the name is not shared,
 # `ttl` and `hlim`, respectively.
-@if ( Version::number >= 30200 )
+@if ( Version::number >= 30201 )
 event icmp_router_advertisement(c: connection, info: icmp_info, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options)
     {
     local i = info;

--- a/scripts/CVE-2020-16898.zeek
+++ b/scripts/CVE-2020-16898.zeek
@@ -5,6 +5,8 @@ module CVE_2020_16898;
 # Author: Yacin Nadji, Research Team @Corelight. yacin.nadji@corelight.com, @ynadji
 # Version: 0.1
 
+@load base/misc/version
+
 const Router_Advertisement = 134;
 const Recursive_DNS_Server_Option = 25;
 
@@ -14,16 +16,31 @@ export {
     };
 }
 
+# This is a hack. See https://github.com/zeek/zeek/wiki/Working-Across-Many-Zeek-Versions for details.
+# Note that each @if branch for the version starts the event block and defines two local variables:
+# `i`, which contains the ICMP info/conn object and `ttl`. This was done so both versions can have
+# exactly one baseline file for the tests. Essentially, fields with shared names between `icmp_info`
+# and `icmp_conn` will use `i` and `ttl` will be used for the variable where the name is not shared,
+# `ttl` and `hlim`, respectively.
+@if ( Version::number >= 30200 )
 event icmp_router_advertisement(c: connection, info: icmp_info, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options)
     {
+    local i = info;
+    local ttl = info$ttl;
+@else
+event icmp_router_advertisement(c: connection, icmp: icmp_conn, cur_hop_limit: count, managed: bool, other: bool, home_agent: bool, pref: count, proxy: bool, rsv: count, router_lifetime: interval, reachable_time: interval, retrans_timer: interval, options: icmp6_nd_options)
+    {
+    local i = icmp;
+    local ttl = icmp$hlim;
+@endif
     for (element in options)
         {
-        if ( info$v6 && info$itype == Router_Advertisement && options[element]$otype == Recursive_DNS_Server_Option && (options[element]$len % 2) == 0 )
+        if ( i$v6 && i$itype == Router_Advertisement && options[element]$otype == Recursive_DNS_Server_Option && (options[element]$len % 2) == 0 )
             {
              NOTICE([$note=CVE_2020_16898_exploit,
                     $conn=c,
                     $identifier=cat(c$id$orig_h),
-                    $msg=fmt("CVE-2020-16898 exploit detected from %s. https://portal.msrc.microsoft.com/en-us/security-guidance/advisory/CVE-2020-16898#ID0EUGAC . Details from packet for reference: icmp=%s  .  The first record of the options vector=%s ", c$id$orig_h, info, options[0])]);
+                    $msg=fmt("CVE-2020-16898 exploit detected from %s. https://portal.msrc.microsoft.com/en-us/security-guidance/advisory/CVE-2020-16898#ID0EUGAC . Details from packet for reference: icmp=[v6=%s, itype=%d, icode=%d, len=%d, ttl=%d]  .  The first record of the options vector=%s ", c$id$orig_h, i$v6, i$itype, i$icode, i$len, ttl, options[0])]);
             }
         }
     }


### PR DESCRIPTION
This PR uses the `Version::number` to separate the two versions of `icmp_router_advertisement` events that use the deprecated `icmp_conn` parameter and the newer `icmp_info` parameter. This is to support installs that don't upgrade for whatever reason.